### PR TITLE
begins work on roll logging

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,9 +2,10 @@ import { React, useState } from "react";
 import Grid from "@material-ui/core/Grid";
 import Paper from "@material-ui/core/Paper";
 import { makeStyles } from "@material-ui/core/styles";
-import OutcomeTally from "./Components/Outcome.js";
+import OutcomeTally from "./Components/Outcome";
 import Roller from "./Components/ResultSetter";
-import AmountButtons from "./Components/AmountButtons.js";
+import AmountButtons from "./Components/AmountButtons";
+import LogInterpreter from "./Components/LogInterpreter";
 
 const useStyles = makeStyles({
   root: {
@@ -16,6 +17,7 @@ const useStyles = makeStyles({
 export const App = () => {
   const [rollAmount, setRollAmount] = useState([0, 0, 0, 0, 0, 0]);
   const [result, setResult] = useState([0, 0, 0, 0, 0, 0]);
+  const [rollLog, setRollLog] = useState();
   const classes = useStyles();
 
   return (
@@ -23,10 +25,11 @@ export const App = () => {
       <Grid container direction="row" spacing={3} alignItems="flex-start">
         <Grid container item lg={4} direction="row">
           <Grid item>{AmountButtons(rollAmount, setRollAmount)}</Grid>
-          <Grid item>{Roller(rollAmount, setResult)}</Grid>
+          <Grid item>{Roller(rollAmount, setResult, setRollLog)}</Grid>
         </Grid>
         <Grid container item lg={8} spacing={3} alignContent="space-around">
           {OutcomeTally(result)}
+          {rollLog ? LogInterpreter(rollAmount, rollLog) : ""}
         </Grid>
       </Grid>
     </Paper>

--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,7 @@ const useStyles = makeStyles({
 
 export const App = () => {
   const [rollAmount, setRollAmount] = useState([0, 0, 0, 0, 0, 0]);
+  const [rolledAmount, setRolledAmount] = useState();
   const [result, setResult] = useState([0, 0, 0, 0, 0, 0]);
   const [rollLog, setRollLog] = useState();
   const classes = useStyles();
@@ -25,11 +26,13 @@ export const App = () => {
       <Grid container direction="row" spacing={3} alignItems="flex-start">
         <Grid container item lg={4} direction="row">
           <Grid item>{AmountButtons(rollAmount, setRollAmount)}</Grid>
-          <Grid item>{Roller(rollAmount, setResult, setRollLog)}</Grid>
+          <Grid item>
+            {Roller(rollAmount, setResult, setRollLog, setRolledAmount)}
+          </Grid>
         </Grid>
         <Grid container item lg={8} spacing={3} alignContent="space-around">
           {OutcomeTally(result)}
-          {rollLog ? LogInterpreter(rollAmount, rollLog) : ""}
+          {rollLog ? LogInterpreter(rolledAmount, rollLog) : ""}
         </Grid>
       </Grid>
     </Paper>

--- a/src/App.js
+++ b/src/App.js
@@ -32,7 +32,9 @@ export const App = () => {
         </Grid>
         <Grid container item lg={8} spacing={3} alignContent="space-around">
           {OutcomeTally(result)}
-          {rollLog ? LogInterpreter(rolledAmount, rollLog) : ""}
+          <Grid item lg={12}>
+            {LogInterpreter(rolledAmount, rollLog)}
+          </Grid>
         </Grid>
       </Grid>
     </Paper>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,7 +1,7 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
+import { render, screen } from "@testing-library/react";
+import App from "./App";
 
-test('renders learn react link', () => {
+test("renders learn react link", () => {
   render(<App />);
   const linkElement = screen.getByText(/learn react/i);
   expect(linkElement).toBeInTheDocument();

--- a/src/Components/Constants.js
+++ b/src/Components/Constants.js
@@ -21,7 +21,13 @@ export const RESULT_NAMES = [
   "Triumph",
   "Failure",
   "Threat",
-  "Despair"
+  "Despair",
+  "Success and Advantage",
+  "Advantage and Advantage",
+  "Success and Success",
+  "Failure and Failure",
+  "Threat and Threat",
+  "Threat and Failure"
 ];
 
 export default { DICE_MATRIX, DICE_NAMES, RESULT_NAMES };

--- a/src/Components/Constants.js
+++ b/src/Components/Constants.js
@@ -27,7 +27,8 @@ export const RESULT_NAMES = [
   "Success and Success",
   "Failure and Failure",
   "Threat and Threat",
-  "Threat and Failure"
+  "Threat and Failure",
+  "Blank"
 ];
 
 export default { DICE_MATRIX, DICE_NAMES, RESULT_NAMES };

--- a/src/Components/LogInterpreter.js
+++ b/src/Components/LogInterpreter.js
@@ -1,20 +1,41 @@
 import React from "react";
 import RollLog from "./RollLog";
 import { DICE_NAMES, RESULT_NAMES } from "./Constants";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableContainer from "@material-ui/core/TableContainer";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import Paper from "@material-ui/core/Paper";
 
 export const LogInterpreter = (amount, log) => {
   let baseLog = RollLog(amount, log);
-  return baseLog.map(x => {
+  let logContents = baseLog.map(x => {
     if (baseLog[baseLog.indexOf(x)]) {
       return baseLog[baseLog.indexOf(x)].map(y => {
         return (
-          <p>
-            {DICE_NAMES[baseLog.indexOf(x)]}: {RESULT_NAMES[y]}
-          </p>
+          <TableRow>
+            <TableCell>{DICE_NAMES[baseLog.indexOf(x)]}</TableCell>
+            <TableCell align="right">{RESULT_NAMES[y]}</TableCell>
+          </TableRow>
         );
       });
     }
   });
+  return (
+    <TableContainer components={Paper}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Dice</TableCell>
+            <TableCell align="right">Results</TableCell>
+          </TableRow>
+        </TableHead>
+        {logContents}
+      </Table>
+    </TableContainer>
+  );
 };
 
 export default LogInterpreter;

--- a/src/Components/LogInterpreter.js
+++ b/src/Components/LogInterpreter.js
@@ -9,7 +9,7 @@ export const LogInterpreter = (amount, log) => {
       return baseLog[baseLog.indexOf(x)].map(y => {
         return (
           <p>
-            {DICE_NAMES[baseLog.indexOf(x)]}: {y}
+            {DICE_NAMES[baseLog.indexOf(x)]}: {RESULT_NAMES[y]}
           </p>
         );
       });

--- a/src/Components/LogInterpreter.js
+++ b/src/Components/LogInterpreter.js
@@ -1,0 +1,20 @@
+import React from "react";
+import RollLog from "./RollLog";
+import { DICE_NAMES, RESULT_NAMES } from "./Constants";
+
+export const LogInterpreter = (amount, log) => {
+  let baseLog = RollLog(amount, log);
+  return baseLog.map(x => {
+    if (baseLog[baseLog.indexOf(x)]) {
+      return baseLog[baseLog.indexOf(x)].map(y => {
+        return (
+          <p>
+            {DICE_NAMES[baseLog.indexOf(x)]}: {y}
+          </p>
+        );
+      });
+    }
+  });
+};
+
+export default LogInterpreter;

--- a/src/Components/LogInterpreter.js
+++ b/src/Components/LogInterpreter.js
@@ -1,41 +1,58 @@
 import React from "react";
 import RollLog from "./RollLog";
 import { DICE_NAMES, RESULT_NAMES } from "./Constants";
+import { makeStyles } from "@material-ui/core/styles";
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
 import TableCell from "@material-ui/core/TableCell";
 import TableContainer from "@material-ui/core/TableContainer";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
 import Paper from "@material-ui/core/Paper";
 
+const useStyles = makeStyles({
+  container: {
+    height: 300,
+    width: "100%"
+  }
+});
+
 export const LogInterpreter = (amount, log) => {
-  let baseLog = RollLog(amount, log);
-  let logContents = baseLog.map(x => {
-    if (baseLog[baseLog.indexOf(x)]) {
-      return baseLog[baseLog.indexOf(x)].map(y => {
-        return (
-          <TableRow>
-            <TableCell>{DICE_NAMES[baseLog.indexOf(x)]}</TableCell>
-            <TableCell align="right">{RESULT_NAMES[y]}</TableCell>
-          </TableRow>
-        );
-      });
-    }
-  });
-  return (
-    <TableContainer components={Paper}>
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell>Dice</TableCell>
-            <TableCell align="right">Results</TableCell>
-          </TableRow>
-        </TableHead>
-        {logContents}
-      </Table>
-    </TableContainer>
-  );
+  const classes = useStyles();
+  if (amount) {
+    let baseLog = RollLog(amount, log);
+    let logContents = baseLog.map(x => {
+      if (baseLog[baseLog.indexOf(x)]) {
+        return baseLog[baseLog.indexOf(x)].map(y => {
+          return (
+            <TableRow>
+              <TableCell>{DICE_NAMES[baseLog.indexOf(x)]}</TableCell>
+              <TableCell align="right">{RESULT_NAMES[y]}</TableCell>
+            </TableRow>
+          );
+        });
+      }
+    });
+    return (
+      <Card raised>
+        <CardContent>
+          <TableContainer components={Paper} className={classes.container}>
+            <Table stickyHeader size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Dice</TableCell>
+                  <TableCell align="right">Results</TableCell>
+                </TableRow>
+              </TableHead>
+              {logContents}
+            </Table>
+          </TableContainer>
+        </CardContent>
+      </Card>
+    );
+  }
 };
 
 export default LogInterpreter;

--- a/src/Components/Outcome.js
+++ b/src/Components/Outcome.js
@@ -26,7 +26,7 @@ export const OutcomeTally = arr => {
     if (x >= 0) {
       v++;
       return (
-        <Grid item classes={{ root: classes.root }}>
+        <Grid item lg={4} classes={{ root: classes.root }}>
           <Card raised>
             <CardContent>
               <Typography color="textPrimary">{RESULT_NAMES[v]}</Typography>
@@ -38,7 +38,7 @@ export const OutcomeTally = arr => {
     } else if (x < 0) {
       v++;
       return (
-        <Grid item classes={{ root: classes.root }}>
+        <Grid item lg={4} classes={{ root: classes.root }}>
           <Card raised>
             <CardContent>
               <Typography color="textPrimary">{RESULT_NAMES[v + 3]}</Typography>

--- a/src/Components/ResultSetter.js
+++ b/src/Components/ResultSetter.js
@@ -2,15 +2,17 @@ import React from "react";
 import { DICE_MATRIX } from "./Constants.js";
 import Button from "@material-ui/core/Button";
 
-export const Roller = (amount, func) => {
+export const Roller = (amount, func, setLog) => {
   let i = 0;
   let results = [0, 0, 0, 0, 0, 0];
+  let rollLog = [];
   const handleRoll = event => {
     amount.map(x => {
       if (x > 0) {
         for (let l = 0; l < x; l++) {
           let roll =
             DICE_MATRIX[i][Math.floor(Math.random() * DICE_MATRIX[i].length)];
+          rollLog.push(roll);
           if (roll == 12) {
             //blank rolled, do nothing
           } else if (roll == 6) {
@@ -30,6 +32,7 @@ export const Roller = (amount, func) => {
           } else {
             results.splice(roll, 1, results[roll] + 1);
           }
+          setLog(rollLog);
         }
         i++;
       } else {

--- a/src/Components/ResultSetter.js
+++ b/src/Components/ResultSetter.js
@@ -2,7 +2,7 @@ import React from "react";
 import { DICE_MATRIX } from "./Constants.js";
 import Button from "@material-ui/core/Button";
 
-export const Roller = (amount, func, setLog) => {
+export const Roller = (amount, func, setLog, setRolled) => {
   let i = 0;
   let results = [0, 0, 0, 0, 0, 0];
   let rollLog = [];
@@ -40,6 +40,7 @@ export const Roller = (amount, func, setLog) => {
         return 0;
       }
     }, []);
+    setRolled(amount);
     return func(results);
   };
   return (

--- a/src/Components/RollLog.js
+++ b/src/Components/RollLog.js
@@ -1,0 +1,16 @@
+import React from "react";
+import { DICE_NAMES, RESULT_NAMES } from "./Constants";
+
+export const RollLog = (amount, log) => {
+  let i = -1;
+  let displayLog = [[], [], [], [], [], []];
+  amount.map(x => {
+    i++;
+    for (let l = 0; l < x; l++) {
+      displayLog[i].push(log[l]);
+    }
+  });
+  return displayLog;
+};
+
+export default RollLog;


### PR DESCRIPTION
Adds RollLog and LogInterpreter, which store the result of each individual die roll in a multidimensional array and then maps through that array to display the roll results of each die. Currently only numerical values are displayed, but ideally in future iterations it will interpret the numerical value as the corresponding Genesys result.

Realized how easy interpreting roll results would be while typing this. Went ahead and committed those changes as well.

Need to style the output but the overall functionality is complete. Closes issue #3.